### PR TITLE
Allow scoped branch names

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -64,7 +64,7 @@ module Slather
             :author_email => (`git log --format=%ae -n 1 HEAD`.chomp || ""),
             :message => (`git log --format=%s -n 1 HEAD`.chomp || "") 
           },
-          :branch => (`git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3`.chomp || "")
+          :branch => (`git ls-remote --heads origin | grep $(git rev-parse HEAD) | cut -d / -f 3-`.chomp || "")
         }
       end
       private :teamcity_git_info


### PR DESCRIPTION
For example `refs/heads/feature/reorganise`

Currently that'll extract `feature`, with a trailing `-` it'll resolve to `feature/reorganise`. It's essential for git flow based repositories.
