### PR TITLE
Another catchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fix nil crash in `project.rb` derived_data_path  
+  [bootstraponline](https://github.com/bootstraponline)
+  [#203](https://github.com/SlatherOrg/slather/pull/203)
+
 * Fix for correct line number for lines that are hit thousands or millions of time in llvm-cov.  
   [Mihai Parv](https://github.com/mihaiparv)
   [#202](https://github.com/SlatherOrg/slather/pull/202), [#196](https://github.com/SlatherOrg/slather/issues/196)
@@ -9,7 +13,6 @@
 * Generate coverate for multiple binaries by passing multiple `--binary-basename` or `--binary-file` arguments, or by using an array in `.slather.yml`  
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)
-
 
 * Support for specifying source file patterns using the `--source-files` option or the source_files key in `.slather.yml`
   [Matej Bukovinski](https://github.com/matej)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+* Make `project.coverage_files` public  
+* Add docs attribute reader to `project.rb`  
+  [bootstraponline](https://github.com/bootstraponline)
+  [#209](https://github.com/SlatherOrg/slather/pull/209)
+
 * Add `--decimals` flag  
   [bootstraponline](https://github.com/bootstraponline)
   [#207](https://github.com/SlatherOrg/slather/pull/207)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+* Add `slather version` command
+  [bootstraponline](https://github.com/bootstraponline)
+  [#208](https://github.com/SlatherOrg/slather/pull/208)
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* Fix for correct line number for lines that are hit thousands or millions of time in llvm-cov.  
+  [Mihai Parv](https://github.com/mihaiparv)
+  [#202](https://github.com/SlatherOrg/slather/pull/202), [#196](https://github.com/SlatherOrg/slather/issues/196)
+
 * Generate coverate for multiple binaries by passing multiple `--binary-basename` or `--binary-file` arguments, or by using an array in `.slather.yml`  
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## master
 
-* Add `slather version` command
+* Add `--decimals` flag  
+  [bootstraponline](https://github.com/bootstraponline)
+  [#207](https://github.com/SlatherOrg/slather/pull/207)
+
+* Add `slather version` command  
   [bootstraponline](https://github.com/bootstraponline)
   [#208](https://github.com/SlatherOrg/slather/pull/208)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+
+## v2.2.0
+
 * Fix nil crash in `project.rb` derived_data_path  
   [bootstraponline](https://github.com/bootstraponline)
   [#203](https://github.com/SlatherOrg/slather/pull/203)
@@ -14,7 +17,7 @@
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)
 
-* Support for specifying source file patterns using the `--source-files` option or the source_files key in `.slather.yml`
+* Support for specifying source file patterns using the `--source-files` option or the source_files key in `.slather.yml`  
   [Matej Bukovinski](https://github.com/matej)
   [#201](https://github.com/SlatherOrg/slather/pull/201)
 
@@ -22,11 +25,11 @@
   [Matyas Hlavacek](https://github.com/matyashlavacek)
   [#182](https://github.com/SlatherOrg/slather/issues/182)
 
-* Search Xcode workspaces for schemes. Workspaces are checked if no matching scheme is found in the project.
+* Search Xcode workspaces for schemes. Workspaces are checked if no matching scheme is found in the project.  
   [Kent Sutherland](https://github.com/ksuther)
   [#193](https://github.com/SlatherOrg/slather/pull/193), [#191](https://github.com/SlatherOrg/slather/issues/191)
 
-* Fix for hit counts in thousands or millions being output as floats intead of integers
+* Fix for hit counts in thousands or millions being output as floats intead of integers  
   [Carl Hill-Popper](https://github.com/chillpop)
   [#190](https://github.com/SlatherOrg/slather/pull/190)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## v2.2.1
+
 * Make `project.coverage_files` public  
 * Add docs attribute reader to `project.rb`  
   [bootstraponline](https://github.com/bootstraponline)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   [Kent Sutherland](https://github.com/ksuther)
   [#188](https://github.com/SlatherOrg/slather/pull/188)
 
+
+* Support for specifying source file patterns using the `--source-files` option or the source_files key in `.slather.yml`
+  [Matej Bukovinski](https://github.com/matej)
+  [#201](https://github.com/SlatherOrg/slather/pull/201)
+
 * Improve getting schemes. Looks for user scheme in case no shared scheme is found.  
   [Matyas Hlavacek](https://github.com/matyashlavacek)
   [#182](https://github.com/SlatherOrg/slather/issues/182)

--- a/bin/slather
+++ b/bin/slather
@@ -4,12 +4,14 @@ require 'yaml'
 require_relative '../lib/slather'
 require_relative '../lib/slather/command/coverage_command'
 require_relative '../lib/slather/command/setup_command'
+require_relative '../lib/slather/command/version_command'
 
 class MainCommand < Clamp::Command
   self.default_subcommand = "coverage"
 
-  subcommand "setup", "Configures a .xcodeproj for test coverage generation", SetupCommand
-  subcommand "coverage", "Computes coverage for the supplied project", CoverageCommand
+  subcommand 'setup', 'Configures a .xcodeproj for test coverage generation', SetupCommand
+  subcommand 'coverage', 'Computes coverage for the supplied project', CoverageCommand
+  subcommand 'version', 'Prints slather version', VersionCommand
 end
 
 MainCommand.run

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -27,6 +27,7 @@ class CoverageCommand < Clamp::Command
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
   option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
+  option ["--decimals"], "DECIMALS", "The amount of decimals to use for % coverage reporting"
 
   def execute
     puts "Slathering..."
@@ -44,6 +45,7 @@ class CoverageCommand < Clamp::Command
     setup_binary_file
     setup_binary_basename
     setup_source_files
+    setup_decimals
 
     project.configure
 
@@ -138,5 +140,9 @@ class CoverageCommand < Clamp::Command
 
   def setup_source_files
     project.source_files = source_files_list if !source_files_list.empty?
+  end
+
+  def setup_decimals
+    project.decimals = decimals if decimals
   end
 end

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -26,7 +26,7 @@ class CoverageCommand < Clamp::Command
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
-  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files", :multivalued => true
+  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode.", :multivalued => true
 
   def execute
     puts "Slathering..."

--- a/lib/slather/command/coverage_command.rb
+++ b/lib/slather/command/coverage_command.rb
@@ -26,6 +26,7 @@ class CoverageCommand < Clamp::Command
   option ["--workspace"], "WORKSPACE", "The workspace that the project was built in"
   option ["--binary-file"], "BINARY_FILE", "The binary file against the which the coverage will be run", :multivalued => true
   option ["--binary-basename"], "BINARY_BASENAME", "Basename of the file against which the coverage will be run", :multivalued => true
+  option ["--source-files"], "SOURCE_FILES", "A Dir.glob compatible pattern used to limit the lookup to specific source files", :multivalued => true
 
   def execute
     puts "Slathering..."
@@ -42,6 +43,7 @@ class CoverageCommand < Clamp::Command
     setup_workspace
     setup_binary_file
     setup_binary_basename
+    setup_source_files
 
     project.configure
 
@@ -132,5 +134,9 @@ class CoverageCommand < Clamp::Command
 
   def setup_binary_basename
     project.binary_basename = binary_basename_list if !binary_basename_list.empty?
+  end
+
+  def setup_source_files
+    project.source_files = source_files_list if !source_files_list.empty?
   end
 end

--- a/lib/slather/command/version_command.rb
+++ b/lib/slather/command/version_command.rb
@@ -1,0 +1,6 @@
+class VersionCommand < Clamp::Command
+
+  def execute
+    puts "slather #{Slather::VERSION}"
+  end
+end

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -5,6 +5,8 @@ module Slather
   module CoverageService
     module HtmlOutput
 
+      attr_reader :docs
+
       def coverage_file_class
         if input_format == "profdata"
           Slather::ProfdataCoverageFile

--- a/lib/slather/coverage_service/html_output.rb
+++ b/lib/slather/coverage_service/html_output.rb
@@ -79,7 +79,7 @@ module Slather
           cov.h4 {
             percentage = (total_tested_lines / total_relevant_lines.to_f) * 100.0
             cov.span "Total Coverage : "
-            cov.span '%.2f%%' % percentage, :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
+            cov.span decimal_f(percentage) + '%', :class => class_for_coverage_percentage(percentage), :id => "total_coverage"
           }
 
           cov.input(:class => "search", :placeholder => "Search")
@@ -105,7 +105,7 @@ module Slather
                 cov.tr {
                   percentage = coverage_file.percentage_lines_tested
 
-                  cov.td { cov.span '%.2f' % percentage, :class => "percentage #{class_for_coverage_percentage(percentage)} data_percentage" }
+                  cov.td { cov.span decimal_f(percentage), :class => "percentage #{class_for_coverage_percentage(percentage)} data_percentage" }
                   cov.td(:class => "data_filename") {
                     cov.a filename, :href => filename_link
                   }
@@ -140,7 +140,7 @@ module Slather
         builder = Nokogiri::HTML::Builder.with(template.at('#reports')) { |cov|
           cov.h2(:class => "cov_title") {
             cov.span("Coverage for \"#{filename}\"" + (!is_file_empty ? " : " : ""))
-            cov.span("#{'%.2f' % percentage}%", :class => class_for_coverage_percentage(percentage)) unless is_file_empty
+            cov.span("#{decimal_f(percentage)}%", :class => class_for_coverage_percentage(percentage)) unless is_file_empty
           }
 
           cov.h4("(#{coverage_file.num_lines_tested} of #{coverage_file.num_lines_testable} relevant lines covered)", :class => "cov_subtitle")

--- a/lib/slather/coverage_service/simple_output.rb
+++ b/lib/slather/coverage_service/simple_output.rb
@@ -19,7 +19,7 @@ module Slather
 
           lines_tested = coverage_file.num_lines_tested
           total_lines = coverage_file.num_lines_testable
-          percentage = '%.2f' % [coverage_file.percentage_lines_tested]
+          percentage = decimal_f([coverage_file.percentage_lines_tested])
 
           total_project_lines_tested += lines_tested
           total_project_lines += total_lines
@@ -42,7 +42,7 @@ module Slather
           puts "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='%i']" % total_project_lines
         end
 
-        total_percentage = '%.2f' % [(total_project_lines_tested / total_project_lines.to_f) * 100.0]
+        total_percentage = decimal_f([(total_project_lines_tested / total_project_lines.to_f) * 100.0])
         puts "Test Coverage: #{total_percentage}%"
       end
 

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -25,7 +25,7 @@ module Slather
 
     def path_on_first_line?
       path = self.source.split("\n")[0].sub ":", ""
-      Pathname(path).exist?
+      !path.include?("1|//")
     end
 
     def source_file_pathname

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -80,7 +80,6 @@ module Slather
 
     def line_coverage_data
       source_code_lines.map do |line|
-        puts "L: #{line}"
         coverage_for_line(line)
       end
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -16,12 +16,17 @@ module Slather
     end
 
     def create_line_data
-      all_lines = self.source.split("\n")[1..-1]
+      all_lines = source_code_lines
       line_data = Hash.new
       all_lines.each { |line| line_data[line_number_in_line(line)] = line }
       self.line_data = line_data
     end
     private :create_line_data
+
+    def path_on_first_line?
+      path = self.source.split("\n")[0].sub ":", ""
+      Pathname(path).exist?
+    end
 
     def source_file_pathname
       @source_file_pathname ||= begin
@@ -30,8 +35,16 @@ module Slather
       end
     end
 
+    def source_file_pathname= (source_file_pathname)
+        @source_file_pathname = source_file_pathname
+    end
+
     def source_file
       File.new(source_file_pathname)
+    end
+
+    def source_code_lines
+      self.source.split("\n")[(path_on_first_line? ? 1 : 0)..-1]
     end
 
     def source_data
@@ -40,7 +53,7 @@ module Slather
 
     def all_lines
       if @all_lines == nil
-        @all_lines = self.source.split("\n")[1..-1]
+        @all_lines = source_code_lines
       end
       @all_lines
     end
@@ -66,7 +79,8 @@ module Slather
     end
 
     def line_coverage_data
-      self.source.split("\n")[1..-1].map do |line|
+      source_code_lines.map do |line|
+        puts "L: #{line}"
         coverage_for_line(line)
       end
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -134,6 +134,7 @@ module Slather
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
         "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
+        # This indicates a llvm-cov coverage warning (happens with ccache in some cases)
         "isn't covered."]
     end
     private :platform_ignore_list

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -133,7 +133,8 @@ module Slather
     def platform_ignore_list
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
-        "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h"]
+        "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
+        "isn't covered."]
     end
     private :platform_ignore_list
   end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -61,6 +61,17 @@ module Slather
           when /[0-9]+/
             return match.to_i
         end
+      else
+        # llvm-cov outputs hit counts as 25.3k or 3.8M, so check this pattern as well
+        did_match = line =~ /^(\s*)(\d+\.\d+)(k|M)\|(\s*)(\d+)\|/
+
+        if did_match
+          match = $5.strip
+          case match
+            when /[0-9]+/
+              return match.to_i
+          end
+        end
       end
       0
     end

--- a/lib/slather/profdata_coverage_file.rb
+++ b/lib/slather/profdata_coverage_file.rb
@@ -148,7 +148,8 @@ module Slather
       ["MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h",
         "MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/objc/objc.h",
         "MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h",
-        # This indicates a llvm-cov coverage warning (happens with ccache in some cases)
+        # This indicates a llvm-cov coverage warning (occurs if a passed in source file 
+        # is not covered or with ccache in some cases).
         "isn't covered."]
     end
     private :platform_ignore_list

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -130,6 +130,8 @@ module Slather
 
           coverage_files.concat(files.map do |source|
             coverage_file = coverage_file_class.new(self, source)
+            # If a single source file is used, the resulting output does not contain the file name.
+            coverage_file.source_file_pathname = source_files.first if source_files.count == 1
             !coverage_file.ignored? ? coverage_file : nil
           end.compact)
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -82,10 +82,13 @@ module Slather
         buildAction = nil
       end
 
-      build_settings = `xcodebuild #{projectOrWorkspaceArgument} #{schemeArgument} -showBuildSettings #{buildAction}`
+      # redirect stderr to avoid xcodebuild errors being printed.
+      build_settings = `xcodebuild #{projectOrWorkspaceArgument} #{schemeArgument} -showBuildSettings #{buildAction} 2>&1`
 
       if build_settings
-        derived_data_path = build_settings.match(/ OBJROOT = (.+)/)[1]
+        derived_data_path = build_settings.match(/ OBJROOT = (.+)/)
+        # when match fails derived_data_path is nil
+        derived_data_path = derived_data_path[1] if derived_data_path
       end
 
       if derived_data_path == nil

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -329,7 +329,7 @@ module Slather
 
     def configure_binary_file
       if self.input_format == "profdata"
-        self.binary_file = load_option_array("binary_file")
+        self.binary_file = load_option_array("binary_file") || find_binary_files
       end
     end
 

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -322,7 +322,7 @@ module Slather
     end
 
     def configure_binary_file
-      if self.input_format == "profdata"
+      if self.binary_file == nil and self.input_format == "profdata"
         binary_file_yml = self.class.yml["binary_file"]
 
         # Need to check the type in the config file because binary_file can be a string or array

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -27,8 +27,8 @@ module Xcodeproj
 
       # Patch xcschemes too
       if format == :clang
-        if Gem::Requirement.new('~> 0.27') =~ Gem::Version.new(Xcodeproj::VERSION)
-          # @todo This will require to bump the xcodeproj dependency to ~> 0.27
+        if Gem::Requirement.new('>= 0.28.2') =~ Gem::Version.new(Xcodeproj::VERSION)
+          # @todo This will require to bump the xcodeproj dependency to >= 0.28.2
           # (which would require to bump cocoapods too)
           schemes_path = Xcodeproj::XCScheme.shared_data_dir(self.path)
           Xcodeproj::Project.schemes(self.path).each do |scheme_name|

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -322,7 +322,7 @@ module Slather
     end
 
     def configure_binary_file
-      if self.input_format == "profdata"
+      if self.input_format == "profdata"  && !self.binary_file
         binary_file_yml = self.class.yml["binary_file"]
 
         # Need to check the type in the config file because binary_file can be a string or array

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -466,11 +466,23 @@ module Slather
     end
 
     def find_source_files
-      patterns = self.source_files ? self.source_files : self.class.yml["source_files"]
-      return if patterns.nil?
+      if self.source_files
+        source_files = self.source_files
+      else
+        source_files_yml = self.class.yml["source_files"]
+
+        # Need to check the type in the config file because source_files can be a string or array
+        if source_files_yml and source_files_yml.is_a? Array
+          source_files = source_files_yml
+        elsif source_files_yml
+          source_files = [source_files_yml]
+        else
+          return
+        end
+      end
 
       current_dir = Pathname("./").realpath
-      paths = patterns.flat_map { |pattern| Dir.glob(pattern) }.uniq
+      paths = source_files.flat_map { |pattern| Dir.glob(pattern) }.uniq
 
       paths.map do |path|
         source_file_absolute_path = Pathname(path).realpath

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -107,7 +107,6 @@ module Slather
         gcov_coverage_files
       end
     end
-    private :coverage_files
 
     def gcov_coverage_files
       coverage_files = Dir["#{build_directory}/**/*.gcno"].map do |file|

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = "2.2.0"
+  VERSION = '2.2.0' unless defined?(Slather::VERSION)
 end

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/lib/slather/version.rb
+++ b/lib/slather/version.rb
@@ -1,3 +1,3 @@
 module Slather
-  VERSION = '2.2.0' unless defined?(Slather::VERSION)
+  VERSION = '2.2.1' unless defined?(Slather::VERSION)
 end

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", ">= 0.39.0", "< 1.1.0"
+  spec.add_development_dependency "cocoapods", "~> 1.0"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", ">= 0.28.2", "< 1.1.0"
+  spec.add_dependency "xcodeproj", "~> 1.1"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end

--- a/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
+++ b/spec/fixtures/fixtures.xcworkspace/xcshareddata/xcschemes/fixturesTestsWorkspace.xcscheme
@@ -5,6 +5,22 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+               BuildableName = "libfixtures.a"
+               BlueprintName = "fixtures"
+               ReferencedContainer = "container:fixtures.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -23,6 +39,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -36,6 +61,15 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C9A202C195965F10013B6B3"
+            BuildableName = "libfixtures.a"
+            BlueprintName = "fixtures"
+            ReferencedContainer = "container:fixtures.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/spec/slather/coverage_file_spec.rb
+++ b/spec/slather/coverage_file_spec.rb
@@ -11,7 +11,7 @@ describe Slather::CoverageFile do
   end
 
   let(:coverage_file) do
-    fixtures_project.send(:coverage_files).detect { |cf| cf.source_file_pathname.basename.to_s == "fixtures.m" }
+    fixtures_project.coverage_files.detect { |cf| cf.source_file_pathname.basename.to_s == "fixtures.m" }
   end
 
   describe "#initialize" do
@@ -42,7 +42,7 @@ describe Slather::CoverageFile do
     ["cpp", "mm", "m"].each do |file_ext|
       it "should work for #{file_ext} files" do
         file_name = "fixtures_#{file_ext}.#{file_ext}"
-        coverage_file = fixtures_project.send(:coverage_files).detect { |cf| cf.source_file_pathname.basename.to_s == file_name }
+        coverage_file = fixtures_project.coverage_files.detect { |cf| cf.source_file_pathname.basename.to_s == file_name }
         expect(coverage_file.source_file_pathname).to eq(fixtures_project["fixtures/#{file_name}"].real_path)
       end
     end
@@ -124,7 +124,7 @@ OBJC
     }
 
     let(:line_coverage_file) do
-      fixtures_project.send(:coverage_files).detect { |cf| cf.source_file_pathname.basename.to_s == "fixtures.m" }
+      fixtures_project.coverage_files.detect { |cf| cf.source_file_pathname.basename.to_s == "fixtures.m" }
     end
 
     describe "#coverage_for_line" do
@@ -166,7 +166,7 @@ OBJC
   describe "branch coverage" do
 
     let(:branch_coverage_file) do
-      fixtures_project.send(:coverage_files).detect { |cf| cf.source_file_pathname.basename.to_s == "Branches.m" }
+      fixtures_project.coverage_files.detect { |cf| cf.source_file_pathname.basename.to_s == "Branches.m" }
     end
 
     describe "branch_coverage_data" do
@@ -281,7 +281,7 @@ OBJC
   describe "empty coverage data" do
 
     let(:empty_file) do
-      fixtures_project.send(:coverage_files).detect { |cf| cf.source_file_pathname.basename.to_s == "Empty.m" }
+      fixtures_project.coverage_files.detect { |cf| cf.source_file_pathname.basename.to_s == "Empty.m" }
     end
 
     describe "gcov_data" do

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -34,7 +34,7 @@ describe Slather::CoverageService::Coveralls do
       it "should return valid json for coveralls coverage gcov data" do
         allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"travis-ci\"}").excluding("source_files")
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 
       it "should raise an error if there is no TRAVIS_JOB_ID" do
@@ -50,7 +50,7 @@ describe Slather::CoverageService::Coveralls do
         allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         allow(fixtures_project).to receive(:coverage_access_token).and_return("abc123")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"travis-pro\",\"repo_token\":\"abc123\"}").excluding("source_files")
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 
       it "should raise an error if there is no TRAVIS_JOB_ID" do
@@ -69,7 +69,7 @@ describe Slather::CoverageService::Coveralls do
         allow(fixtures_project).to receive(:circleci_build_url).and_return("https://circleci.com/gh/Bruce/Wayne/1")
         allow(fixtures_project).to receive(:circleci_git_info).and_return({ :head => { :id => "ababa123", :author_name => "bwayne", :message => "hello" }, :branch => "master" })
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"circleci\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"service_build_url\":\"https://circleci.com/gh/Bruce/Wayne/1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 
       it "should raise an error if there is no CIRCLE_BUILD_NUM" do
@@ -87,7 +87,7 @@ describe Slather::CoverageService::Coveralls do
         allow(fixtures_project).to receive(:jenkins_git_info).and_return({head: {id: "master", author_name: "author", message: "pull title" }, branch: "branch"})
         allow(fixtures_project).to receive(:jenkins_branch_name).and_return('master')
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"jenkins\",\"repo_token\":\"abc123\",\"git\":{\"head\":{\"id\":\"master\",\"author_name\":\"author\",\"message\":\"pull title\"},\"branch\":\"branch\"}}").excluding("source_files")
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
 
       it "should raise an error if there is no BUILD_ID" do
@@ -156,7 +156,7 @@ describe Slather::CoverageService::Coveralls do
       it "should return valid json for coveralls coverage profdata data" do
         allow(fixtures_project).to receive(:travis_job_id).and_return("9182")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"travis-ci\"}").excluding("source_files")
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.coverage_files.map(&:as_json).to_json).at_path("source_files")
       end
     end
   end

--- a/spec/slather/coverage_service/html_output_spec.rb
+++ b/spec/slather/coverage_service/html_output_spec.rb
@@ -26,6 +26,10 @@ describe Slather::CoverageService::HtmlOutput do
     it "should return CoverageFile" do
       expect(fixtures_project.send(:coverage_file_class)).to eq(Slather::ProfdataCoverageFile)
     end
+
+    it "should allow accessing docs via attribute" do
+      expect(fixtures_project.docs).to eq(nil)
+    end
   end
 
   describe '#post' do

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -70,8 +70,16 @@ describe Slather::ProfdataCoverageFile do
   end
 
   describe "#line_number_in_line" do
-    it "should return the correct line number" do
+    it "should return the correct line number for coverage represented as decimals" do
       expect(profdata_coverage_file.line_number_in_line("      0|   40|    func applicationWillTerminate(application: UIApplication) {")).to eq(40)
+    end
+
+    it "should return the correct line number for coverage represented as thousands" do
+      expect(profdata_coverage_file.line_number_in_line("  11.8k|   41|    func applicationWillTerminate(application: UIApplication) {")).to eq(41)
+    end
+
+    it "should return the correct line number for coverage represented as milions" do
+      expect(profdata_coverage_file.line_number_in_line("  2.58M|   42|    func applicationWillTerminate(application: UIApplication) {")).to eq(42)
     end
   end
 

--- a/spec/slather/profdata_coverage_spec.rb
+++ b/spec/slather/profdata_coverage_spec.rb
@@ -139,6 +139,12 @@ describe Slather::ProfdataCoverageFile do
       expect(ignorable_file.ignored?).to be_truthy
     end
 
+    it "should ignore warnings" do
+      ignorable_file = Slather::ProfdataCoverageFile.new(fixtures_project, "warning The file '/Users/ci/.ccache/tmp/CALayer-KI.stdout.macmini08.92540.QAQaxt.mi' isn't covered.")
+
+      expect(ignorable_file.ignored?).to be_truthy
+    end
+
   end
 
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -53,14 +53,14 @@ describe Slather::Project do
     it "should return coverage file objects of type coverage_file_class for unignored project files" do
       fixtures_project.ignore_list = ["*fixturesTests*"]
       allow(fixtures_project).to receive(:dedupe) { |coverage_files| coverage_files }
-      coverage_files = fixtures_project.send(:coverage_files)
+      coverage_files = fixtures_project.coverage_files
       coverage_files.each { |cf| expect(cf.kind_of?(SpecCoverageFile)).to be_truthy }
       expect(coverage_files.map { |cf| cf.source_file_pathname.basename.to_s }).to eq(["fixtures.m", "peekaview.m"])
     end
 
     it "should raise an exception if no unignored project coverage file files were found" do
       fixtures_project.ignore_list = ["*fixturesTests*", "*fixtures*"]
-      expect {fixtures_project.send(:coverage_files)}.to raise_error(StandardError)
+      expect {fixtures_project.coverage_files}.to raise_error(StandardError)
     end
   end
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -136,6 +136,14 @@ describe Slather::Project do
       allow(Dir).to receive(:[]).with("#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/**/*.xctest").and_return(["#{build_directory}/Build/Intermediates/CodeCoverage/FixtureScheme/FixtureAppTests.xctest"])
     end
 
+    it "should use binary_file" do
+      fixtures_project.binary_file = ["/path/to/binary"]
+      fixtures_project.send(:configure_binary_file)
+      binary_file_location = fixtures_project.send(:binary_file)
+      expect(binary_file_location.count).to eq(1)
+      expect(binary_file_location.first).to eq("/path/to/binary")
+    end
+
     it "should find the product path provided a scheme" do
       allow(fixtures_project).to receive(:scheme).and_return("fixtures")
       fixtures_project.send(:configure_binary_file)

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -503,4 +503,20 @@ describe Slather::Project do
     end
   end
 
+  def decimal_f *args
+    fixtures_project.decimal_f *args
+  end
+
+  describe '#decimal_f' do
+    it 'should preserve length 2 decimals for backwards compatibility' do
+      expect(decimal_f('100.00')).to eq('100.00')
+      expect(decimal_f('50.00')).to eq('50.00')
+    end
+
+    it 'should convert length >= 3 decimals to floats' do
+      fixtures_project.decimals = 3
+      expect(decimal_f('100.000')).to eq('100.0')
+      expect(decimal_f('50.00000')).to eq('50.0')
+    end
+  end
 end

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -464,4 +464,35 @@ describe Slather::Project do
       fixtures_project.send(:configure)
     end
   end
+
+  describe "#source_files" do
+
+    let(:fixtures_project) do
+      proj = Slather::Project.open(FIXTURES_PROJECT_PATH)
+      proj.build_directory = TEMP_DERIVED_DATA_PATH
+      proj.input_format = "profdata"
+      proj.source_files = ["./**/fixtures{,Two}.m"]
+      proj.binary_basename = ["fixturesTests", "libfixturesTwo"]
+      proj.configure
+      proj
+    end
+
+    it "should find relevant source files" do
+      source_files = fixtures_project.find_source_files
+      expect(source_files.count).to eq(2)
+      expect(source_files.first.to_s).to include("fixtures.m")
+      expect(source_files.last.to_s).to include("fixturesTwo.m")
+    end
+
+    it "should print out the coverage for each file, and then total coverage" do
+      ["spec/fixtures/fixtures/fixtures.m: 3 of 6 lines (50.00%)",
+      "spec/fixtures/fixturesTwo/fixturesTwo.m: 6 of 6 lines (100.00%)",
+      "Test Coverage: 75.00%"
+      ].each do |line|
+        expect(fixtures_project).to receive(:puts).with(line)
+      end
+      fixtures_project.post
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 if ENV['SIMPLECOV']
   require 'simplecov'
   SimpleCov.start
-else
+elsif ENV['TRAVIS']
   require 'coveralls'
   Coveralls.wear!
 end


### PR DESCRIPTION
I'm trying to update `modi`'s CocoaPods dependency to `~> 1.0.0`, but am seeing this:

```
Bundler could not find compatible versions for gem "claide":
  In Gemfile:
    cocoapods (~> 1.0) was resolved to 1.0.0, which depends on
      claide (< 2.0, >= 1.0.0)

    danger (~> 0.7.3) was resolved to 0.7.4, which depends on
      claide

    fastlane (~> 1.51) was resolved to 1.93.1, which depends on
      xcode-install (~> 1.4.0) was resolved to 1.4.0, which depends on
        claide (< 1.1.0, >= 0.9.1)

    slather was resolved to 2.1.0, which depends on
      xcodeproj (< 1.1.0, >= 0.28.2) was resolved to 0.28.2, which depends on
        claide (~> 0.9.1)
```

It's a bit hard to decipher, but I think this can be resolved by updating slather so that the `xcodeproj` dependency is less restrictive, which will make the transitive `claide` dependency less restrictive as well.
# Testing (two options)
1. Point modi's Gemfile reference for `gem 'slather'` back to `keatongreve/slather`, `bundle update`, and test slather on TC/local.
2. Merge as is, `bundle update` in modi to update the `master` reference, test.
